### PR TITLE
feat(window.py): add `set_title()` method

### DIFF
--- a/simulat/core/ui/windows/window_management/window.py
+++ b/simulat/core/ui/windows/window_management/window.py
@@ -88,6 +88,10 @@ class Window():
                bl=0, br=0):
         self.window.border(ls, rs, ts, bs, tl, tr, bl, br)
 
+    def set_title(self, title: str):
+        self.addstr(0, -1, title)
+        self.refresh()
+
     def subwin(self, nlines: int, ncols: int, y: int, x: int, *, make_panel: bool = False, reverse: bool = False):
         from .subwindow import SubWindow
         return SubWindow(self.window, nlines, ncols, y, x, make_panel=make_panel, reverse=reverse)


### PR DESCRIPTION
## PR type (check all applicable)

- [x] `   feat   ` :sparkles: features
- [ ] `   fix    ` :bug: bugfixes
- [ ] `   docs   ` :book: documentation changes
- [ ] `  style   ` :gem: style
- [ ] `refactor` :package: code refactoring
- [ ] `   perf   ` :rocket: performance improvements
- [ ] `   test   ` :rotating_light: tests
- [ ] `  build   ` :construction_worker: build
- [ ] `    ci    ` :robot: continuous integration
- [ ] `  chore   ` :ticket: chores
- [ ] `  revert  ` :back: reverts

## PR description

This PR adds the ability to easily title windows.

## Related Tickets

- related issue #
- closes #

## Instructions, Screenshots

In `Window()` call add the `title` argument.

## Anything else? (post-deployment tasks) [optional]

## Fun time: What gif best describes this PR and/or your feelings? [optional]
