### PR TITLE
feat(containers): add text input widget

### DIFF
--- a/main.py
+++ b/main.py
@@ -20,6 +20,7 @@ def main(stdscr):
 def main_menu(stdscr):
     from simulat.core.ui.windows.topbar import topbar
     from simulat.core.ui.windows.window_management.container import container_test
+    from simulat.core.ui.windows.widgets.text_input_widget import test_textinputwidget
 
 
     topbar.title_win.addstr(0, -1, "main menu")
@@ -31,6 +32,7 @@ def main_menu(stdscr):
                                  MenuEntry("exit", "exit", "the most useful button", sys.exit),
                                  MenuEntry("board", "DEBUG: Example Board", None, None),
                                  MenuEntry("container", "DEBUG: Example Container", None, None),
+                                 MenuEntry("text_input", "DEBUG: Text Input Widget", None, None)
                              ]
                              )
 
@@ -44,6 +46,11 @@ def main_menu(stdscr):
     elif result == 'board':
         from simulat.core.init import init_game_map
         init_game_map()
+
+    elif result == 'text_input':
+        menu.erase()
+        menu.refresh()
+        test_textinputwidget()
 
 
 

--- a/simulat/core/ui/windows/widgets/text_input_widget.py
+++ b/simulat/core/ui/windows/widgets/text_input_widget.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+
+import curses as cs
+from curses.textpad import Textbox
+
+from .widget import Widget, WidgetLoopEnd
+from ..window_management.derwindow import DerWindow
+
+
+class TextInputWidget(Widget):
+    def __init__(self, parent, *, default_text: str = ""):
+        super().__init__(parent)
+
+        self.default_text = default_text
+
+        # init input window
+        self.input_window = DerWindow(self.window, self.max_y - 2,
+                                      self.max_x - 2, 0, 1, make_panel=False)
+        self.is_one_line = self.input_window.max_y == 1
+
+        self.textbox = Textbox(self.input_window.window, insert_mode=True)
+
+        # format input window
+        self.input_window.attron(cs.A_UNDERLINE)
+        self.input_window.window.bkgd(" ", cs.A_UNDERLINE)
+
+        # add tip text
+        self.addstr(self.max_y - 1, 1,
+                    "press `Return` to submit" if self.is_one_line
+                    else "press `Ctrl-G` to submit", cs.A_DIM)
+
+        # refresh
+        self.refresh()
+        self.input_window.refresh()
+
+        # set cursor
+        cs.curs_set(2)  # show cursor
+
+    def _input(self, key):
+        if key in [cs.KEY_ENTER, 10] and self.is_one_line or key == 7:
+            cs.curs_set(0)  # hide cursor
+            raise WidgetLoopEnd(self.textbox.gather().strip("\n").strip(' '))
+        else:
+            self.textbox.do_command(key)
+            self.input_window.refresh()
+
+    def mvwin(self, y: int, x: int):
+        self.input_window.mvwin(y, x + 1)
+        return super().mvwin(y, x)
+
+
+def test_textinputwidget():
+    from ..window_management.container import Container
+
+    container1 = Container("text input widget test", "lorem ipsum, one line",
+                           7, 28,
+                           "center", "center")
+    container1.widget = TextInputWidget(container1)
+    result1 = container1.loop()
+
+    container2 = Container("text input widget test", "lorem ipsum, multiline",
+                           8, 28,
+                           "center", "center")
+    container2.widget = TextInputWidget(container2)
+    result2 = container2.loop()
+
+    raise Exception(result1, result2)

--- a/simulat/core/ui/windows/window_management/container.py
+++ b/simulat/core/ui/windows/window_management/container.py
@@ -57,9 +57,7 @@ class Container(Window):
                 result = e.args[0]
                 break
 
-            if key == ord('d'):
-                self.move_relative(1, 1)
-            elif key == cs.KEY_RESIZE:
+            if key == cs.KEY_RESIZE:
                 self.move("center", "center")
             elif key == ord('q'):
                 break

--- a/simulat/core/ui/windows/window_management/container.py
+++ b/simulat/core/ui/windows/window_management/container.py
@@ -43,6 +43,8 @@ class Container(Window):
             Any: The result of the widget's loop.
         """
 
+        result = None  # default
+
         while True:
             key = self.getch()
 
@@ -51,7 +53,8 @@ class Container(Window):
 
             try:
                 self.widget._input(key)
-            except WidgetLoopEnd:
+            except WidgetLoopEnd as e:
+                result = e.args[0]
                 break
 
             if key == ord('d'):
@@ -61,7 +64,7 @@ class Container(Window):
             elif key == ord('q'):
                 break
 
-        return self.widget.result
+        return result
 
     def update_title(self, title: str):
         """Updates the title of the window.


### PR DESCRIPTION
## PR type (check all applicable)

- [x] `   feat   ` :sparkles: features
- [x] `   fix    ` :bug: bugfixes
- [ ] `   docs   ` :book: documentation changes
- [ ] `  style   ` :gem: style
- [ ] `refactor` :package: code refactoring
- [ ] `   perf   ` :rocket: performance improvements
- [ ] `   test   ` :rotating_light: tests
- [ ] `  build   ` :construction_worker: build
- [ ] `    ci    ` :robot: continuous integration
- [x] `  chore   ` :ticket: chores
- [ ] `  revert  ` :back: reverts

## PR description

This PR adds a text input widget `TextInputWidget` which can be used to get text (single or multiple lines) from the user.

## Related Tickets

- related issue #
- closes #

## Instructions, Screenshots

![text input widget in action](https://github.com/pufereq/simulat/assets/94570596/62b0b5b7-d7be-4d06-b4b1-76bd01c15a06)
The \`TextInputWidget\` in action (single line and multiline). The exception shows results of both widgets.


## Anything else? (post-deployment tasks) [optional]

## Fun time: What gif best describes this PR and/or your feelings? [optional]
