### PR TITLE
feat: add console

### DIFF
--- a/simulat/core/init.py
+++ b/simulat/core/init.py
@@ -93,6 +93,7 @@ def init_curses_inner(stdscr):
     init_colors()
     init_content_win()
     init_topbar(stdscr)
+    init_console()
 
 
 def init_game_map():
@@ -102,3 +103,11 @@ def init_game_map():
 
     game_map = GameMap()
     game_map._start_loop()
+
+
+def init_console():
+    global console
+    # Console
+    from simulat.core.ui.windows.console import Console
+
+    console = Console("console", None, 16, 64, "center", "center")

--- a/simulat/core/loop.py
+++ b/simulat/core/loop.py
@@ -42,5 +42,10 @@ def _loop(keypress: int):
     Args:
         keypress (int): The keypress to handle.
     """
+    if keypress == ord("`"):
+        from .init import console
+        console.loop()
+
+
     game_map._input(keypress)
     game_map._refresh_map()

--- a/simulat/core/ui/windows/console.py
+++ b/simulat/core/ui/windows/console.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+
+import curses as cs
+import curses.panel
+
+from .window_management.container import Container
+from .widgets.text_input_widget import TextInputWidget
+
+
+class Console(Container):
+    def __init__(self, title: str, description: str | None, nlines: int, ncols: int, y: int | str, x: int | str):
+        super().__init__(title, description, nlines, ncols, y, x)
+
+        self.widget = TextInputWidget(self, default_text="command")
+
+    def loop(self):
+        result = ("import simulat; " + (super().loop() or "")).replace("\n", "")
+        try:
+            parsed = compile(result, "<string>", "exec")
+        except Exception as e:
+            self.show_result(f"{e.__class__.__name__}: {e}")
+            return
+
+        self.show_result(self.execute_command(parsed))
+
+    def show_result(self, result):
+        from .window_management.container import Container
+        from .widgets.widget import Widget
+
+        self.panel.hide()
+        self.widget.panel.hide()
+        curses.panel.update_panels()
+
+        container = Container("console result", str(result), 10, 40, "center", "center")
+        container.widget = Widget(container)
+
+        container.display()
+        container.refresh_all()
+        container.loop()
+
+    def execute_command(self, command: str):
+        """Executes a command.
+
+        Args:
+            command (str): The command to execute.
+        """
+        try:
+            return eval(command)
+        except Exception as e:
+            self.show_result(f"{e.__class__.__name__}: {e}")

--- a/simulat/core/ui/windows/console.py
+++ b/simulat/core/ui/windows/console.py
@@ -14,9 +14,9 @@ class Console(Container):
         self.widget = TextInputWidget(self, default_text="command")
 
     def loop(self):
-        result = ("import simulat; " + (super().loop() or "")).replace("\n", "")
+        result = super().loop().replace("\n", "")
         try:
-            parsed = compile(result, "<string>", "exec")
+            parsed = compile(result, "<string>", "eval")
         except Exception as e:
             self.show_result(f"{e.__class__.__name__}: {e}")
             return
@@ -45,6 +45,7 @@ class Console(Container):
             command (str): The command to execute.
         """
         try:
-            return eval(command)
+            import simulat
+            return str(eval(command, {"simulat": simulat}))
         except Exception as e:
             self.show_result(f"{e.__class__.__name__}: {e}")

--- a/simulat/core/ui/windows/console.py
+++ b/simulat/core/ui/windows/console.py
@@ -14,7 +14,7 @@ class Console(Container):
         self.widget = TextInputWidget(self, default_text="command")
 
     def loop(self):
-        result = super().loop().replace("\n", "")
+        result = str(super().loop()).replace("\n", "")
         try:
             parsed = compile(result, "<string>", "eval")
         except Exception as e:

--- a/simulat/core/ui/windows/widgets/text_input_widget.py
+++ b/simulat/core/ui/windows/widgets/text_input_widget.py
@@ -32,8 +32,11 @@ class TextInputWidget(Widget):
         self.refresh()
         self.input_window.refresh()
 
-        # set cursor
+    def loop_start_hook(self):
+        super().loop_start_hook()
+
         cs.curs_set(2)  # show cursor
+        self.input_window.window.refresh()
 
     def _input(self, key):
         if key in [cs.KEY_ENTER, 10] and self.is_one_line or key == 7:

--- a/simulat/core/ui/windows/widgets/text_input_widget.py
+++ b/simulat/core/ui/windows/widgets/text_input_widget.py
@@ -20,6 +20,9 @@ class TextInputWidget(Widget):
 
         self.textbox = Textbox(self.input_window.window, insert_mode=True)
 
+        # add default text
+        self.input_window.addstr(0, 0, self.default_text)
+
         # add tip text
         self.addstr(self.max_y - 1, 1,
                     "press `Return` to submit" if self.is_one_line

--- a/simulat/core/ui/windows/widgets/text_input_widget.py
+++ b/simulat/core/ui/windows/widgets/text_input_widget.py
@@ -20,10 +20,6 @@ class TextInputWidget(Widget):
 
         self.textbox = Textbox(self.input_window.window, insert_mode=True)
 
-        # format input window
-        self.input_window.attron(cs.A_UNDERLINE)
-        self.input_window.window.bkgd(" ", cs.A_UNDERLINE)
-
         # add tip text
         self.addstr(self.max_y - 1, 1,
                     "press `Return` to submit" if self.is_one_line

--- a/simulat/core/ui/windows/widgets/widget.py
+++ b/simulat/core/ui/windows/widgets/widget.py
@@ -20,11 +20,16 @@ class Widget(DerWindow):
             parent (Container): The parent container window.
         """
         if parent.description:
-            super().__init__(parent.window, parent.max_y - 4, parent.max_x - 2, 3, 1, make_panel=False)
+            super().__init__(parent.window, parent.max_y - 4, parent.max_x - 2, 3, 1, make_panel=True)
         else:
-            super().__init__(parent.window, parent.max_y - 2, parent.max_x - 2, 1, 1, make_panel=False)
+            super().__init__(parent.window, parent.max_y - 2, parent.max_x - 2, 1, 1, make_panel=True)
 
         self.result = None
+        self.panel.hide()
+
+    def loop_start_hook(self):
+        self.panel.top()
+        self.panel.show()
 
     def _wrap_str_to_width(self, text: str) -> str:
         """Wraps a string to the width of the widget.

--- a/simulat/core/ui/windows/window_management/container.py
+++ b/simulat/core/ui/windows/window_management/container.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import curses as cs
+import curses.panel
 
 from .window import Window
 
@@ -35,6 +36,16 @@ class Container(Window):
 
         self.update_title(self.title)
         self.update_description(self.description)
+        self.panel.hide()
+        curses.panel.update_panels()
+
+    def display(self):
+        self.panel.show()
+        self.panel.top()
+        self.widget.panel.show()
+        self.widget.panel.top()
+        curses.panel.update_panels()
+        self.refresh_all()
 
     def loop(self):
         """Starts the loop of the container window.
@@ -44,6 +55,7 @@ class Container(Window):
         """
 
         result = None  # default
+        self.display()
 
         while True:
             key = self.getch()

--- a/simulat/core/ui/windows/window_management/container.py
+++ b/simulat/core/ui/windows/window_management/container.py
@@ -56,6 +56,7 @@ class Container(Window):
 
         result = None  # default
         self.display()
+        self.widget.loop_start_hook()
 
         while True:
             key = self.getch()

--- a/simulat/core/ui/windows/window_management/window.py
+++ b/simulat/core/ui/windows/window_management/window.py
@@ -22,11 +22,7 @@ class Window():
             self.window.attrset(cs.A_REVERSE)
 
         if make_panel:
-            from .subwindow import SubWindow
-            if type(self.window) is SubWindow:
-                self.panel = curses.panel.new_panel(self.window.window)
-            else:
-                self.panel = curses.panel.new_panel(self.window)
+            self.panel = curses.panel.new_panel(self.window)
 
         self.keypad(True)
 


### PR DESCRIPTION
## PR type (check all applicable)

- [x] `   feat   ` :sparkles: features
- [x] `   fix    ` :bug: bugfixes
- [ ] `   docs   ` :book: documentation changes
- [ ] `  style   ` :gem: style
- [x] `refactor` :package: code refactoring
- [ ] `   perf   ` :rocket: performance improvements
- [ ] `   test   ` :rotating_light: tests
- [ ] `  build   ` :construction_worker: build
- [ ] `    ci    ` :robot: continuous integration
- [x] `  chore   ` :ticket: chores
- [ ] `  revert  ` :back: reverts

## PR description

This PR:
- adds a `Console` class (container) which can be used to execute python commands from within simulat _(`import simulat` is prepended to every command)_.
- fixes text being overwritten in `TextInputWidget` because of the underline attribute
- removes unnecessary type checks in `_common_init()` - `window.py`.
- makes containers and widgets hidden by default. can still be shown using the new `display()` method in the `Container` class which is called by `loop()`.
- adds a `loop_start_hook()` method to the `Widget` class which may contain preparation to display the widget.

## Related Tickets

- related issue #
- closes #

## Instructions, Screenshots

To show the console while in the game map, press the backtick key. The console works on the TextInputWidget so the command can be confirmed using `^G` (CTRL-G). After confirmation, the result will be shown in another container as shown below:

![A showcase of Console](https://github.com/pufereq/simulat/assets/94570596/a1e42f63-dc77-4403-926c-90a16881e14e)

## Anything else? (post-deployment tasks) [optional]

## Fun time: What gif best describes this PR and/or your feelings? [optional]
